### PR TITLE
Correct visualization of autocomplete on correlated issue.

### DIFF
--- a/stylesheets/application.css
+++ b/stylesheets/application.css
@@ -1057,7 +1057,7 @@
 .ui-autocomplete {
   position: absolute;
   cursor: default;
-  z-index: 3;
+  z-index: 10;
   -moz-border-radius: 0;
   -webkit-border-radius: 0;
   border-radius: 0;


### PR DESCRIPTION
On issue creation and edit, the "related issue" autocomplete appears on the back of the main content.
With this fix now it doesn't but I'm not sure if this change create some other problem on other page.