### PR TITLE
Delete unusefull position absolute

### DIFF
--- a/stylesheets/application.css
+++ b/stylesheets/application.css
@@ -5136,9 +5136,6 @@ fieldset, fieldset.box {
   background: none;
   margin-bottom: 1em; }
   fieldset legend, fieldset.box legend {
-    position: absolute;
-    top: 0;
-    left: 0;
     font-size: 1.2em;
     width: 100%;
     border-bottom: 1px solid #CCCCCC; }


### PR DESCRIPTION
On Chrome 46.0.2490.80 the title of additional transitions of the admin/workflow, "fieldset legend" was not displayed correctly, with this fix now you can read the title of additional transitions.