### PR TITLE
Fix menu-children behaviour in main menu

### DIFF
--- a/sass/application.sass
+++ b/sass/application.sass
@@ -416,6 +416,17 @@ select
 	margin: 0 -1.5em
 	padding: 0 1.5em
 
+	ul.menu-children
+		background: $medium-grey
+		display: none
+		position: absolute
+		z-index: 99
+		right: 0
+		left: 0
+		box-shadow: inset 0 -1px 0 $grey
+		&.visible
+			display: block
+
 	li
 		display: table-cell
 		width: 1%

--- a/stylesheets/application.css
+++ b/stylesheets/application.css
@@ -4584,6 +4584,16 @@ button:focus, input[type="button"]:focus, input[type="reset"]:focus, input[type=
     clear: both;
     content: "";
     display: table; }
+  #main-menu ul.menu-children {
+    background: #CCCCCC;
+    display: none;
+    position: absolute;
+    z-index: 99;
+    right: 0;
+    left: 0;
+    box-shadow: inset 0 -1px 0 #777777; }
+    #main-menu ul.menu-children.visible {
+      display: block; }
   #main-menu li {
     display: table-cell;
     width: 1%; }


### PR DESCRIPTION
Fix menu-children behaviour in main menu
- fix visible / not visible behaviour
- reduce size of the + button (position: absolute on menu-children)
- add darker background + box-shadow

-> issue specific to redmine 3.x ?