### PR TITLE
fixing tab buttons position, it was messed up in the middle of the page

### DIFF
--- a/sass/application.sass
+++ b/sass/application.sass
@@ -1954,11 +1954,11 @@ p.progress-info
 					color: $text
 
 div.tabs-buttons
-	position: absolute
+	position: absolute 
 	right: 0
 	width: 3em
 	background: white
-	bottom: 0
+	// bottom: 0
 	border-bottom: 1px solid $medium-grey
 
 button.tab-left, button.tab-right

--- a/stylesheets/application.css
+++ b/stylesheets/application.css
@@ -5928,7 +5928,6 @@ div.tabs-buttons {
   right: 0;
   width: 3em;
   background: white;
-  bottom: 0;
   border-bottom: 1px solid #CCCCCC; }
 
 button.tab-left, button.tab-right {


### PR DESCRIPTION
Fixing the place of the tab buttons it was here:


![tabbuttons](https://cloud.githubusercontent.com/assets/3543067/18805009/d0035b54-8203-11e6-98a2-f2330c8f6602.png)


