### PR TITLE
better styling for details in issues

### DIFF
--- a/sass/application.sass
+++ b/sass/application.sass
@@ -1317,11 +1317,22 @@ div#issue-changesets p
 	margin-bottom: 1em
 
 .journal
+	div.thumbnails
+		padding: 0.5em 1em 0.5em 1em
+		background-color: lighten($white, 0.5%)
+		border: 1px solid $light-grey
 
 	ul.details
 		list-style-type: none
-		padding-left: 0
+		padding: 0.5em 1em 0.5em 1em
 		color: $grey
+		background-color: lighten($white, 0.5%)
+		margin-top: 0em
+		border: 1px solid $light-grey
+
+		& + div.thumbnails
+			border-top: 0
+			margin-top: -1.05em 
 
 		img
 			margin: 0 0 -3px 4px
@@ -1640,6 +1651,7 @@ div.attachments span.author
 
 div.thumbnails
 	margin-top: .6em
+
 
 div.thumbnails div
 	background: #fff

--- a/stylesheets/application.css
+++ b/stylesheets/application.css
@@ -5313,10 +5313,20 @@ div#issue-changesets p {
   margin-top: 0;
   margin-bottom: 1em; }
 
+.journal div.thumbnails {
+  padding: 0.5em 1em 0.5em 1em;
+  background-color: #fafafa;
+  border: 1px solid #F2F2F2; }
 .journal ul.details {
   list-style-type: none;
-  padding-left: 0;
-  color: #777777; }
+  padding: 0.5em 1em 0.5em 1em;
+  color: #777777;
+  background-color: #fafafa;
+  margin-top: 0em;
+  border: 1px solid #F2F2F2; }
+  .journal ul.details + div.thumbnails {
+    border-top: 0;
+    margin-top: -1.05em; }
   .journal ul.details img {
     margin: 0 0 -3px 4px; }
 


### PR DESCRIPTION
Issue journal entries with details let the context menu somehow hanging:

![hanging-menu](https://cloud.githubusercontent.com/assets/3543067/18807291/72a509b8-8243-11e6-834c-699f1a8ac241.png)

Instead of this, I add some styling to the details log to justify the hanging visually:

![styling](https://cloud.githubusercontent.com/assets/3543067/18807300/9479de2e-8243-11e6-9c61-df27cf11d590.png)

and merge thumbnails with it if any:

![merge](https://cloud.githubusercontent.com/assets/3543067/18807309/ac111688-8243-11e6-8b42-c15cf0d15ff1.png)

