### PR TITLE
fix multiselect buttons

### DIFF
--- a/sass/application.sass
+++ b/sass/application.sass
@@ -1286,6 +1286,8 @@ fieldset#filters td.add-filter
 	padding-left: 8px
 	margin-left: 0
 	cursor: pointer
+	padding-right: 8px
+	margin-right: 0.5em
 
 .buttons
 	margin-bottom: 1.4em

--- a/stylesheets/application.css
+++ b/stylesheets/application.css
@@ -5284,7 +5284,9 @@ fieldset#filters td.add-filter {
   background: url(../images/bullet_toggle_plus.png) no-repeat 0 40%;
   padding-left: 8px;
   margin-left: 0;
-  cursor: pointer; }
+  cursor: pointer;
+  padding-right: 8px;
+  margin-right: 0.5em; }
 
 .buttons {
   margin-bottom: 1.4em;


### PR DESCRIPTION
Multiselect openner buttons are somehow hidden by the contect coming next… fixing this.

This now looks like this

![multiselect](https://cloud.githubusercontent.com/assets/3543067/18807412/31bc7b36-8246-11e6-9290-43ae9df676d3.png)
