### PR TITLE
made the query buttons centered again

### DIFF
--- a/sass/application.sass
+++ b/sass/application.sass
@@ -728,6 +728,7 @@ div.modal
 		text-align: right
 		margin-bottom: 0
 
+
 input#openid_url
 	background: url(../images/openid-bg.gif) no-repeat
 	background-color: #fff
@@ -788,6 +789,7 @@ table
 				width: 15%
 				white-space: nowrap
 				text-align: right
+
 
 			&.buttons a
 				padding-right: .6em
@@ -1007,8 +1009,6 @@ table.query-columns td.buttons
 	vertical-align: middle
 	text-align: center
 
-table.query-columns td.buttons input[type=button]
-	width: 35px
 
 h3.version
 	margin-top: 0

--- a/stylesheets/application.css
+++ b/stylesheets/application.css
@@ -5044,9 +5044,6 @@ table.query-columns td.buttons {
   vertical-align: middle;
   text-align: center; }
 
-table.query-columns td.buttons input[type=button] {
-  width: 35px; }
-
 h3.version {
   margin-top: 0; }
   h3.version:before {


### PR DESCRIPTION
Fixing the query column buttons:

![buttons-styling](https://cloud.githubusercontent.com/assets/3543067/18808480/1ed84f68-8264-11e6-8eb3-46edb66eeddb.png)

simple fix: do not force a size anymore :)